### PR TITLE
 	Added "Open Account" menu option when viewing accounts from tray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Wavebox-win32-x64/
 Wavebox-win32-ia32-Installer/
 *.log
 credentials.js
+.DS_Store

--- a/src/scenes/mailboxes/src/Components/Tray/Tray.js
+++ b/src/scenes/mailboxes/src/Components/Tray/Tray.js
@@ -79,7 +79,7 @@ module.exports = React.createClass({
     const mailboxMenuItems = mailboxState.allMailboxes().map((mailbox) => {
       const trayMessages = mailbox.trayMessages
       const messageItemsSignature = trayMessages.map((message) => message.id).join(':')
-      const messageItems = trayMessages.map((message) => {
+      var   messageItems = trayMessages.map((message) => {
         return {
           id: message.id,
           label: message.text,
@@ -91,13 +91,25 @@ module.exports = React.createClass({
         }
       })
 
+      messageItems.unshift(
+        {
+          label: "Open Account",
+          click: (e) => {
+            ipcRenderer.send('focus-app', { })
+            mailboxActions.changeActive(mailbox.__id__)
+          }
+        },
+
+        { type: 'separator' }
+      )
+
       return {
         signature: messageItemsSignature,
         label: [
           mailbox.unreadCount && mailbox.showUnreadBadge ? `(${mailbox.unreadCount})` : undefined,
           mailbox.displayName || 'Untitled'
         ].filter((item) => !!item).join(' '),
-        submenu: messageItems.length === 0 ? [
+        submenu: messageItems.length === 2 ? [...messageItems, 
           { label: 'No messages', enabled: false }
         ] : messageItems
       }


### PR DESCRIPTION
Based on [Issue #14 ](https://github.com/wavebox/waveboxapp/issues/14), I've added a menu option in the tray to open Wavebox to a specific account. Also I added a line in `.gitignore` to ignore the `.DS_Store` that macOS generates automatically.

Additionally, this is my first pull request to the project, and the first one overall!