### PR TITLE
fix startup

### DIFF
--- a/src/app/src/stores/mailbox/mailboxActions.js
+++ b/src/app/src/stores/mailbox/mailboxActions.js
@@ -15,6 +15,7 @@ class MailboxActions extends CoreMailboxActions {
   */
   load () {
     const mailboxData = mailboxPersistence.allJSONItems()
+    const mailboxIndex = mailboxData[PERSISTENCE_INDEX_KEY] || []
     return {
       allAvatars: avatarPersistence.allItems(),
       allMailboxes: Object.keys(mailboxData).reduce((acc, id) => {
@@ -23,8 +24,8 @@ class MailboxActions extends CoreMailboxActions {
         }
         return acc
       }, {}),
-      mailboxIndex: mailboxData[PERSISTENCE_INDEX_KEY] || [],
-      activeMailbox: mailboxData[PERSISTENCE_INDEX_KEY][0] || null,
+      mailboxIndex,
+      activeMailbox: mailboxIndex || null,
       activeService: CoreMailbox.SERVICE_TYPES.DEFAULT,
       sleepingServices: {}
     }

--- a/src/app/src/stores/mailbox/mailboxActions.js
+++ b/src/app/src/stores/mailbox/mailboxActions.js
@@ -25,7 +25,7 @@ class MailboxActions extends CoreMailboxActions {
         return acc
       }, {}),
       mailboxIndex,
-      activeMailbox: mailboxIndex || null,
+      activeMailbox: mailboxIndex[0] || null,
       activeService: CoreMailbox.SERVICE_TYPES.DEFAULT,
       sleepingServices: {}
     }


### PR DESCRIPTION
At the very first startup, if nothing was ever configured `mailboxData[PERSISTENCE_INDEX_KEY]` can be undefined which leads to the following exception :
```
App threw an error during load
TypeError: Cannot read property '0' of undefined
    at Object.load (./waveboxapp/bin/app/webpack:/src/app/src/stores/mailbox/mailboxActions.js:27:22)
    at Object.action [as load] (./waveboxapp/bin/app/webpack:/src/app/node_modules/alt/src/actions/index.js:15:45)
    at WaveboxApp_WaveboxApp.start (./bin/waveboxapp/bin/app/webpack:/src/app/src/WaveboxApp/WaveboxApp.js:67:20)
    at ./waveboxapp/bin/app/webpack:/src/app/src/index.js:21:14
    at Object.<anonymous> (./waveboxapp/bin/app/webpack:/src/app/src/index.js:1:2)
    at __webpack_require__ (./waveboxapp/bin/app/webpack:/webpack/bootstrap 7b958711baecf27cea91:19:1)
    at ./waveboxapp/bin/app/webpack:/webpack/bootstrap 7b958711baecf27cea91:62:1
    at Object.<anonymous> (./waveboxapp/bin/app/index.js:67:10)
    at Object.<anonymous> (./waveboxapp/bin/app/index.js:30871:3)
    at Module._compile (module.js:571:32)
```