### PR TITLE
add context menu for translation

### DIFF
--- a/src/app/src/Services/ContextMenuService.js
+++ b/src/app/src/Services/ContextMenuService.js
@@ -189,6 +189,10 @@ class ContextMenuService {
         label: `Search Google for “${displayText}”`,
         click: () => { shell.openExternal(`https://google.com/search?q=${encodeURIComponent(params.selectionText)}`) }
       })
+      template.push({
+        label: `Translate “${displayText}”`,
+        click: () => { shell.openExternal(`http://translate.google.com/#auto/#/${encodeURIComponent(params.selectionText)}`) }
+      })
     }
     return template
   }


### PR DESCRIPTION
Quick win, while waiting for a better solution.
This allow to translate any selected text using the contextual menu.
It opens google translate with auto source language detection.