### PR TITLE
Add requireInteraction support

### DIFF
--- a/src/app/src/Notifications/LinuxNotification.js
+++ b/src/app/src/Notifications/LinuxNotification.js
@@ -220,9 +220,12 @@ class LinuxNotification {
   presentNotification (id, senderId, options) {
     // Auto-clear
     clearTimeout(this[privNotificationExpirer])
-    this[privNotificationExpirer] = setTimeout(() => {
-      this.clearNotifications()
-    }, 3000)
+    // Respect requireInteraction option
+    if (!options.requireInteraction) {
+      this[privNotificationExpirer] = setTimeout(() => {
+        this.clearNotifications()
+      }, 3000)
+    }
 
     // Save
     this[privNotifications].set(id, { options, senderId, id })


### PR DESCRIPTION
Dont auto-close notification where requireInteraction is set to true.
It will be useful when user want to create "very important" notification.