### PR TITLE
Update logic when clicking on a macOS notification body

### DIFF
--- a/src/scenes/mailboxes/src/Notifications/EnhancedNotificationRenderer.js
+++ b/src/scenes/mailboxes/src/Notifications/EnhancedNotificationRenderer.js
@@ -79,10 +79,11 @@ class EnhancedNotificationRenderer {
       soundName: NotificationRendererUtils.preparedServiceSound(mailbox, service, settingsState),
       bundleId: OSX_APP_BUNDLE_ID
     })
-    notif.addEventListener('click', () => {
+    notif.addEventListener('click', (ev) => {
       if (clickHandler) {
         clickHandler(notification.data)
       }
+      ev.target.notification.close();
     })
   }
 


### PR DESCRIPTION
Clicking on the macOS mail notification body should automatically close the notification, similar to the `Show` action. This is consistent with other macOS apps . When notifications are set to be persistent, clicking on the body does the same thing as `Show`, but doesn't actually close the notification.