### PR TITLE
Fix some naming of links to be consistent with other items in list

### DIFF
--- a/src/app/src/Services/ContextMenuService.js
+++ b/src/app/src/Services/ContextMenuService.js
@@ -209,12 +209,12 @@ class ContextMenuService {
         })
       }
       template.push({
-        label: 'Copy link Address',
+        label: 'Copy Link Address',
         click: () => { clipboard.writeText(params.linkURL) }
       })
       template.push({ type: 'separator' })
       template.push({
-        label: 'Open link with Wavebox',
+        label: 'Open Link with Wavebox',
         submenu: [
           {
             label: 'Open Link in New Window',


### PR DESCRIPTION
Minor change to fix the naming of links. It might be that the links are correct but I thought I might create pull request anyway on the labels. Please ignore if this is wrong.

![image](https://user-images.githubusercontent.com/383031/47178986-1f73df80-d31d-11e8-9b60-5957b11b1545.png)
