### PR TITLE
Update notification close logic to support Electron notifications on macOS Catalina

### DIFF
--- a/src/scenes/mailboxes/src/Notifications/NotificationService.js
+++ b/src/scenes/mailboxes/src/Notifications/NotificationService.js
@@ -250,6 +250,8 @@ class NotificationService extends EventEmitter {
         this.__state__.openSystemNotifications.delete(id)
         if (systemNotification.notification && systemNotification.notification.close) {
           systemNotification.notification.close()
+        } else if (systemNotification.close) {
+          systemNotification.close()
         }
       }
     })


### PR DESCRIPTION
Without this, `Alerts` style notifications on macOS Catalina are not being closed after the associated email is read.